### PR TITLE
2. Add CI pipeline

### DIFF
--- a/‎.github/workflows/dotnet.yml‎
+++ b/‎.github/workflows/dotnet.yml‎
@@ -1,0 +1,55 @@
+name: .NET CI
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Restore
+        run: dotnet restore SpaceBattle.sln
+
+      - name: Build
+        run: dotnet build SpaceBattle.sln --no-restore --configuration Release
+
+      - name: Test + Coverage (fail if <90%)
+        run: >
+          dotnet test SpaceBattle.sln
+          --no-build
+          --configuration Release
+          /p:CollectCoverage=true
+          /p:CoverletOutput=./TestResults/Coverage/
+          /p:CoverletOutputFormat=cobertura
+          /p:Threshold=90
+          /p:ThresholdType=line
+          /p:ThresholdStat=total
+
+      - name: Install ReportGenerator
+        run: dotnet tool install -g dotnet-reportgenerator-globaltool
+
+      - name: Generate Coverage Report
+        run: >
+          reportgenerator
+          -reports:**/coverage.cobertura.xml
+          -targetdir:coveragereport
+          -reporttypes:MarkdownSummaryGithub
+
+      - name: Comment Coverage Report in PR
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          path: coveragereport/SummaryGithub.md
+          


### PR DESCRIPTION
Настроить github CI pipeline, который:

- собирает проект,
- выполняет все тесты,
- вычисляет коэффициент покрытия кода тестами,
- публикует в комментариях отчет о покрытии.

**Критерий приемки:**
Pipeline срабатывает только на PR.
Pipeline оптимально расходует минуты, например, не производит компиляцию проекта повторно при выполнении тестирования.
**Важно!** Коэффициент покрытия кода тестами любого PR должен быть больше 90%.